### PR TITLE
Distance calc

### DIFF
--- a/client/actions/length.js
+++ b/client/actions/length.js
@@ -1,15 +1,9 @@
-export function addLength(id, dist){  
+export function addLength(id, dist){
   return {
     type: 'ADD_LENGTH',
     payload: {
       id,
       dist
     }
-  }
-}
-
-export function clearLengths(){
-  return {
-    type: 'CLEAR_LENGTHS'
   }
 }

--- a/client/actions/map.js
+++ b/client/actions/map.js
@@ -1,5 +1,4 @@
 import 'whatwg-fetch'
-import { clearLengths } from './length'
 export function getGeoJSON(ev) {
   return (dispatch, getState) => {
     const map = ev.target
@@ -26,7 +25,6 @@ export function getGeoJSON(ev) {
         return res.json()
       })
       .then(function(newJSON) {
-        clearLengths() //get rid of other lengths
         dispatch({
           type: 'SET_GEOJSON',
           payload: newJSON

--- a/client/components/list/index.jsx
+++ b/client/components/list/index.jsx
@@ -4,8 +4,6 @@ import { bindActionCreators } from 'redux'
 import actions from '../../actions'
 import TrailItem from './trailItem'
 
-const Loader = (props) => (<h2 className='trail__List--loading animated infinite pulse'>Loading trails...</h2>)
-
 const list = ({
   trails,
   loading,
@@ -14,11 +12,14 @@ const list = ({
   active
 }) => (
     <div className="trail__List fadeIn">
-      <h2 className="header">
-      {loading
-        ? (<Loader />)
-        : ('Current Trails')
-      }
+      <h2 className={'header ' + (loading
+       ? 'trail__List--loading animated infinite pulse'
+       : '' )}
+      >
+        {loading
+          ? 'Loading trails...'
+          : 'Current Trails'
+        }
       </h2>
       {trails.map(trail => (
         <TrailItem

--- a/client/components/map/index.jsx
+++ b/client/components/map/index.jsx
@@ -47,8 +47,8 @@ const map = ({
       >
         <Tooltip
           id={feature._id}
-          distance={actions.distance}
-          distances={distances}
+          actions={actions}
+          distance={distances[feature._id]}
           trailName={(feature.properties.NAME || feature.properties.name)}
           isActive={getActive(feature, active)}
         />

--- a/client/components/map/index.jsx
+++ b/client/components/map/index.jsx
@@ -23,7 +23,8 @@ const map = ({
   zoom,
   GeoJSON,
   actions,
-  active
+  active,
+  distances
 }) => (
   <Map
     id="map"
@@ -44,12 +45,13 @@ const map = ({
         {...getCurrentStyle(active, feature)}
         onClick={() => actions.map.setActive(feature._id)}
       >
-        <Tooltip 
-        distance={actions.distance} 
-        trailName={(feature.properties.NAME || feature.properties.name)}
-        isActive={getActive(feature, active)}
-        {...getActive(feature, active)}
-          />
+        <Tooltip
+          id={feature._id}
+          distance={actions.distance}
+          distances={distances}
+          trailName={(feature.properties.NAME || feature.properties.name)}
+          isActive={getActive(feature, active)}
+        />
       </GeoJson>
     )) }
   </Map>
@@ -58,7 +60,7 @@ const map = ({
 const getActive = (feature, active) => feature._id === active
 
 const getCurrentStyle = (active, feature) => (
-  getActive(feature, active) 
+  getActive(feature, active)
     ? activeStyle
     : myStyle
 )
@@ -72,6 +74,7 @@ function eachFeature(feature, layer){
 
 export default connect(
   state => ({
+    distances: state.distances,
     center: state.map.center,
     zoom: state.map.zoom,
     GeoJSON: state.map.geojson,
@@ -80,13 +83,7 @@ export default connect(
   dispatch => ({
     actions: {
       map: bindActionCreators(actions.map, dispatch),
-      distance: bindActionCreators(actions.distance, dispatch) //wrap all functions in this object with the dispatch actions
-      //const bindActionCreators = (obj, dispatch) => (
-      //  Object.keys(obj).reduce((o, k) => {
-      //    o[k] = () => dispatch(o[k](arguments))//wrap all functions with dispatch
-      //    reutrn o
-      //  },
-      //{})
+      distance: bindActionCreators(actions.distance, dispatch)
     }
   })
 )(map)

--- a/client/components/map/mapToolTip.jsx
+++ b/client/components/map/mapToolTip.jsx
@@ -1,25 +1,21 @@
-import React from 'react'
+import React, { Component } from 'react'
 import { Popup } from 'react-leaflet'
-const Tooltip = ({distance, trailName, isActive, ...props}) => (
-  <Popup {...props}>
-    <span className='trail__tooltip'>
-      <h5>
-        { trailName || 'No name given' }
-      </h5>
-      <p>Estimated Distance: {isActive 
-      ? guessLength(props.popupContainer, distance.addLength) + 'Miles'
-      : '' 
-      }
-      </p>
-    </span>
-  </Popup>
-)
 
-function guessLength(layer, addLength) { //get the id out of the layer?
-  let tempLatLng = null
-  const { _latlngs, feature } = layer._layers[layer._leaflet_id-1]
-  const distance = _latlngs.reduce((totalDistance, latlng)=> {
-    if(tempLatLng == null){
+export default class Tooltip extends Component {
+
+  componentWillMount(){
+    this.guessLength()
+  }
+
+  guessLength() { //get the id out of the layer?
+    if(this.props.id in this.props.distances) return // we already mounted this guy once
+
+    const { popupContainer: layer, distance: { addLength } } = this.props
+    const { _latlngs, feature } = layer._layers[layer._leaflet_id-1]
+    let tempLatLng = null
+
+    const distance = _latlngs.reduce((totalDistance, latlng)=> {
+      if(tempLatLng == null){
         tempLatLng = latlng
         return totalDistance
       }
@@ -27,9 +23,24 @@ function guessLength(layer, addLength) { //get the id out of the layer?
       tempLatLng = latlng
       return totalDistance
     }, 0)
+
     const convertedDistance = (0.000621371 * distance).toFixed(2)
     addLength(feature._id, convertedDistance)
     return convertedDistance
-}
+  }
 
-export default Tooltip
+  render(){
+    const { trailName, distances, id, ...props } = this.props
+    return (
+      <Popup {...props}>
+      <span className='trail__tooltip'>
+        <h5>
+          { trailName || 'No name given' }
+        </h5>
+        <p>Estimated Distance: {distances[id]} Miles
+        </p>
+      </span>
+    </Popup>
+    )
+  }
+}

--- a/client/components/map/mapToolTip.jsx
+++ b/client/components/map/mapToolTip.jsx
@@ -8,9 +8,9 @@ export default class Tooltip extends Component {
   }
 
   guessLength() { //get the id out of the layer?
-    if(this.props.id in this.props.distances) return // we already mounted this guy once
+    if(this.props.distance) return // we already mounted this guy once
 
-    const { popupContainer: layer, distance: { addLength } } = this.props
+    const { popupContainer: layer, actions: {distance: { addLength }} } = this.props
     const { _latlngs, feature } = layer._layers[layer._leaflet_id-1]
     let tempLatLng = null
 

--- a/client/reducers/distances.js
+++ b/client/reducers/distances.js
@@ -1,7 +1,5 @@
 export default (state = {}, {type, payload}) => {
   switch(type){
-    case 'CLEAR_LENGTHS':
-      return {}
     case 'ADD_LENGTH':
       return {
         ...state,

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "babel-preset-stage-0": "^6.5.0",
     "babelify": "^7.2.0",
     "browserify": "^13.0.0",
-    "uglifyify": "^3.0.1"
+    "uglifyify": "^3.0.1",
+    "watchify": "^3.7.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
Redo how we calculate distance. Resolves #12. When a trail is mounted, we add it to the distances object. After we calculate the distance, we never clear distances. This should mean less time calculating distances.  I also fixed our 'h2 inside an h2' error. 
